### PR TITLE
Upgrade Build Tools

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+   "parserOptions": {
+       "ecmaVersion": 6,
+       "sourceType": "module",
+       "ecmaFeatures": {
+           "jsx": true
+       }
+   },
+   "rules": {
+       "semi": 2
+   }
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,64 @@
+
+var watchify = require('watchify');
+var browserify = require('browserify');
+var reactify = require('reactify');
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+var source = require('vinyl-source-stream');
+var buffer = require('vinyl-buffer');
+var uglify = require('gulp-uglify');
+var react = require('gulp-react');
+var eslint = require('gulp-eslint');
+var rename = require('gulp-rename');
+var concat = require('gulp-concat');
+var _ = require('lodash');
+
+var customOpts = {
+    entries: ['./src/js/client.jsx'],
+    debug: true
+};
+
+var path = {
+    HTML: 'src/popup.html',
+    ALL: ['src/js/*.js', 'src/js/**/*.js', 'src/popup.html'],
+    JS: ['src/js/*.js', 'src/js/**/*.js'],
+    MINIFIED_OUT: 'client-bundle-min.js',
+    BUILD_PATH: 'build/js'
+}
+
+var opts = _.assign({}, watchify.args, customOpts);
+var b = watchify(browserify(opts));
+
+b.transform(reactify);
+
+gulp.task('watch', ['lint'], bundle);
+b.on('update', bundle);
+b.on('log', gutil.log);
+
+function bundle() {
+    return b.bundle()
+        .on('error', gutil.log.bind(gutil, 'Browserify Error'))
+        .pipe(source('client-bundle.js'))
+        .pipe(buffer())
+        .pipe(minify({
+            exclude: ['tasks'],
+            ignoreFiles: ['.client-bundle.js', '-min.js']
+        }))
+        .pipe(gulp.dest('./build/js'));
+}
+
+gulp.task('build', function(){
+    gulp.src(path.JS)
+        .pipe(react())
+        .pipe(concat(path.MINIFIED_OUT))
+        .pipe(uglify(path.MINIFIED_OUT))
+        .pipe(gulp.dest(path.BUILD_PATH));
+});
+
+gulp.task('lint', function () {
+    return gulp.src(['**/*.js','!node_modules/**', '!build/**/*.js'])
+        .pipe(eslint())
+        // Alternatively use eslint.formatEach() (see Docs).
+        .pipe(eslint.format())
+        .pipe(eslint.failAfterError());
+});

--- a/package.json
+++ b/package.json
@@ -4,15 +4,23 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "watch": "./scripts/watch.sh",
-    "build": "./scripts/build.sh"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "browserify": "^13.0.0",
+    "gulp": "^3.9.1",
+    "gulp-concat": "^2.6.0",
+    "gulp-eslint": "^2.0.0",
+    "gulp-react": "^3.1.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-uglify": "^1.5.2",
+    "gulp-util": "^3.0.7",
     "reactify": "^1.1.1",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
   },
   "browserify": {
@@ -26,6 +34,7 @@
     ]
   },
   "dependencies": {
+    "lodash": "^4.5.0",
     "reflux": "^0.3.0"
   }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-./node_modules/.bin/browserify -t reactify -o build/js/client-bundle.js src/js/client.jsx

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-./node_modules/.bin/watchify -v -t reactify -o build/js/client-bundle.js src/js/client.jsx &
-
-
-for job in `jobs -p`
-do
-  wait $job
-done

--- a/src/popup.html
+++ b/src/popup.html
@@ -15,4 +15,4 @@
 </body>
 <script src="../build/lib/react.min.js"></script>
 <script src="../build/lib/react-dom.min.js"></script>
-<script src='../build/js/client-bundle.js'></script>
+<script src='../build/js/client-bundle-min.js'></script>


### PR DESCRIPTION
This PR hopes to incorporate `gulp`, `eslint`, and whatever else is necessary without breaking the current branch.

`gulpfile.js` currently has:
- `gulp watch` -- the build works but the watch doesn't.  I like this method, but I couldn't get a basic build to work with it yet.
- `gulp build` -- a method for building abstracted from a blog.  Also not working yet, but close.

To-do:
- [ ] Find a working basic build for React/Browserify/Gulp
- [ ] Get sass/eslint/minify working
